### PR TITLE
Update __init__.py - table_classes and table_no_skip_classes fix

### DIFF
--- a/sphinx_material/__init__.py
+++ b/sphinx_material/__init__.py
@@ -33,7 +33,7 @@ def setup(app):
     app.connect("build-finished", reformat_pages)
     app.connect("build-finished", minify_css)
     app.connect("builder-inited", update_html_context)
-    app.connect("config-inited", update_table_classes)
+    app.connect("config-inited", update_table_classes(app, app.config)) # function update_table_classes takes two arguments... tested.. working
     manager = Manager()
     site_pages = manager.list()
     sitemap_links = manager.list()


### PR DESCRIPTION
update_table_classes func was not triggered, when 
   app.connect("config-inited", update_table_classes)
 